### PR TITLE
Limit text to two-thirds of the page wide

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -61,9 +61,9 @@
 
     handleAgeResponse: function(response) {
       var resp = response.getDataTable();
-      var $el = $('<div/>')
-                .append('<h2 class="heading-medium">'+resp.getValue(0, 0)+'</h2>')
-                .append('<p>'+resp.getValue(0, 1)+'</p>')
+      var $el = $('<div class="grid-row"></div>')
+                .append('<h2 class="heading-medium column-two-thirds">'+resp.getValue(0, 0)+'</h2>')
+                .append('<p class="column-two-thirds bottom-gutter">'+resp.getValue(0, 1)+'</p>')
                 .insertAfter(this.$chartEl);
       this.addAges(resp, $el);
     },
@@ -82,12 +82,13 @@
     handlePayResponse: function(response) {
       var resp = response.getDataTable();
       var $el = $('<div/>')
-                .addClass('column-full')
+                .addClass('column-two-thirds clearfix')
                 .append('<h2 class="heading-small">'+resp.getValue(0, 0)+'</h2>')
                 .append('<p>'+resp.getValue(1, 0)+'</p>')
                 .append('<p>'+resp.getValue(2, 0)+'</p>')
                 .append('<p>'+resp.getValue(3, 0)+'</p>')
-                .appendTo($('#women'));
+                .appendTo($('#women'))
+                .wrap('<div class="grid-row"><div class="column-full"></div></div>');
       var $mean = $('<div/>').addClass('data column-one-third')
                   .append('<span class="data-item bold-xxlarge">'+resp.getValue(1, 2)+'%</span>')
                   .append('<span class="data-item bold-xsmall">Lower than men (MEAN)</span>')
@@ -136,7 +137,7 @@
                   .addClass('grid-row')
                   .attr('id', title.replace(/\s/g,'').toLowerCase())
                   .append('<h2 class="column-two-thirds heading-medium">'+resp.getValue(i, 0)+'</h2>')
-                  .append('<p class="column-full">'+resp.getValue(i, 1)+'</p>')
+                  .append('<p class="column-two-thirds bottom-gutter">'+resp.getValue(i, 1)+'</p>')
                   .appendTo(this.$chartEl);
         this.addChart(resp, i, $el);
       }

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -42,3 +42,7 @@ $path: "/public/images/";
     width: 100%;
   }
 }
+
+.bottom-gutter {
+  margin-bottom: $gutter;
+}

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
         </div>
       </div>
       <div class="grid-row">
-        <div class="column-full">
+        <div class="column-two-thirds">
           <p id="js-Intro"></p>
         </div>
       </div>
@@ -52,7 +52,7 @@
         </div>
       </div>
       <div class="grid-row">
-        <div class="column-full">
+        <div class="column-two-thirds">
           <h2 class="heading-medium">Other demographics</h2>
           <p id="js-Footer"></p>
         </div>


### PR DESCRIPTION
Text where the lines get too long is hard to read.

> “Anything from 45 to 75 characters is widely regarded as a satisfactory length of line for a single-column page set in a serifed text face in a text size. The 66-character line (counting both letters
and spaces) is widely regarded as ideal.

– http://webtypography.net/2.1.2

An easy way of stopping the lines getting too long when using the GOV.UK template is to limit text to two thirds of the width of the main column. Doing so reduces the first line of text on your page from 113 to 72 characters.

I also added a bit of spacing between the text and the charts so that the leftmost charts don’t group too strongly with the paragraph above.

Before | After 
---|---
![ministryofjustice github io_normalising-stats_ ipad pro](https://user-images.githubusercontent.com/355079/42237600-2ccb1c46-7ef6-11e8-866a-a3a43e38b320.png) | ![_users_chs_gdsworkspace_normalising-stats_index html ipad pro 1](https://user-images.githubusercontent.com/355079/42237682-67de9d94-7ef6-11e8-9690-750b9afcff56.png)


p.s. It’s really cool that you’re publishing this data 👍👍 